### PR TITLE
修改用户模型中的私有域，会员等级，客服为可空。

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -15,10 +15,10 @@ class UserProfile(AbstractUser):
     mobile = models.CharField(max_length=20)#电话号码
     gender = models.BooleanField(default=True)#1男，0女
     type = models.CharField(max_length=10,choices=(("supplier","供应商"),("giftcompany","礼品公司"),("service","客服"),("admin","系统管管理员")))
-    privatearea = models.ForeignKey(privatearea,on_delete=models.CASCADE)#私有域的外键id
+    privatearea = models.ForeignKey(privatearea,on_delete=models.CASCADE, blank=True, null=True)#私有域的外键id
     inprivatearea = models.BooleanField(default=False)#1开通了私有域，2没有开通私有域
-    viplevel = models.ForeignKey(vipLevel,on_delete=models.CASCADE)#vip等级的外键
-    servicestaff=models.ForeignKey("UserProfile",on_delete=models.CASCADE)#分配的客服的外键
+    viplevel = models.ForeignKey(vipLevel,on_delete=models.CASCADE, blank=True, null=True)#vip等级的外键
+    servicestaff=models.ForeignKey("UserProfile",on_delete=models.CASCADE, blank=True, null=True)#分配的客服的外键
 
     def __str__(self):
         return self.username


### PR DESCRIPTION
由于用户类型管理员，客服并不存在私有域，会员等级，客服关联，所以需要设置相关关联属性为空。